### PR TITLE
Fix QFontDatabase.families() call for PyQt6 compatibility

### DIFF
--- a/vise/main.py
+++ b/vise/main.py
@@ -149,7 +149,7 @@ class Application(QApplication):
         f = self.font()
         if (f.family(), f.pointSize()) == ('Sans Serif', 9):  # Hard coded Qt settings, no user preference detected
             f.setPointSize(10)
-            if 'Ubuntu' in QFontDatabase().families():
+            if 'Ubuntu' in QFontDatabase.families():
                 f.setFamily('Ubuntu')
             self.setFont(f)
         self.downloads = Downloads(self)


### PR DESCRIPTION
#### Problem
On systems using PyQt6 (version 6.9.1 or later), Vise fails to start with a `TypeError: QFontDatabase(a0: QFontDatabase): not enough arguments` at line 152 in `vise/main.py`. This occurs because `families()` is now a static method in PyQt6, but the code attempts to call it on an instance (`QFontDatabase().families()`), which triggers an error.

The error traceback is:
```
Traceback (most recent call last):
  File "/home/cs/work/vise/vise/main.py", line 152, in __init__
    if 'Ubuntu' in QFontDatabase().families():
                   ~~~~~~~~~~~~~^^
TypeError: QFontDatabase(a0: QFontDatabase): not enough arguments
```

This prevents the app from launching and checking for the Ubuntu font family, breaking the font setup logic.

#### Solution
Remove the instance creation parentheses to call `families()` as a static method: change `QFontDatabase().families()` to `QFontDatabase.families()`.


#### Testing
- Tested on Arch Linux with PyQt6 6.9.1 and python-pyqt6-webengine 6.9.0.
- Vise launches successfully, detects the Ubuntu font (after installing `ttf-ubuntu-font-family`), and uses it for UI text rendering.

